### PR TITLE
Query via mu auth, not using sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,31 +24,6 @@ Include the service in `docker-compose.yml`.
       SPRING_SECURITY_CONFIG: "/config/security.yml"
 ```
 
-### Configure Delta Notifier
-
-Include the delta notifier into the stack following the instructions documented
-on [delta-notifier](https://github.com/mu-semtech/delta-notifier). And configure `config/delta/rules.js` to send delta
-messages to the jsonld delta service in the `v0.0.1` format. e.g.:
-
-```
-export default [
-    {
-      match: {
-        subject: {
-        }
-      },
-      callback: {
-        url: "http://jsonld-delta-service/delta", method: "POST"
-      },
-      options: {
-        resourceFormat: "v0.0.1",
-        gracePeriod: 1000,
-        ignoreFromSelf: true
-      }
-    }
-  ]
-```
-
 ### Configure the dispatcher
 
 Add the jsonld-delta-service routes to the [dispatcher](https://github.com/mu-semtech/mu-dispatcher) configuration.
@@ -58,10 +33,6 @@ e.g.:
 ...
 match "/v3/api-docs/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://jsonld-delta-service/v3/api-docs/"
-  end
-
-  match "/changes/*path", %{ layer: :api_services, accept: %{ json: true } } do
-    forward conn, path, "http://jsonld-delta-service/changes/"
   end
 
   match "/consolidated/*path", %{ layer: :api_services, accept: %{ json: true } } do
@@ -114,7 +85,7 @@ server:
         "USER"
       ]
     }
-   ]
+  ]
 
 ```
 
@@ -135,30 +106,20 @@ OpenAPI documentation is available via `/v3/api-docs/`
 
 The JSON-LD response contains:
 
-- A named graph with the consolidated representation of all delta messages. i.e. the result of applying all instert and
+- A named graph with the consolidated representation of all delta messages. i.e. the result of applying all inserted and
   delete messages.
-- The default graph contains a timestamp to be used in subsequent requests to the `/changes` route. e.g.
+- The default graph contains a timestamp to be used in subsequent requests
 
 ```json
    ...
 ],
 "@id": "http://mu.semte.ch/graphs/kalliope/consolidated",
 "date": "2021-05-27T09:26:03.351256816Z",
-"@context": {
-"date": {
-"@id": "http://purl.org/dc/terms/date",
-"@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-}
-}
+  "@context": {
+    "date": {
+      "@id": "http://purl.org/dc/terms/date",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    }
+  }
 }
 ```
-
-### `/changes`
-
-Use the date from a previous `/consolidated` or `/changes` response as `since` parameter.
-
-The response contains:
-
-- Two named graphs with respectively the deleted and inserted triples since the provided date.
-- The default graph contains a timestamp to be used in subsequent requests. Same as for the `/changes` response.
-

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>mu.semte.ch</groupId>
   <artifactId>jsonld-delta-service</artifactId>
-  <version>0.5.5-beta.1</version>
+  <version>0.5.5-SNAPSHOT</version>
   <name>jsonld-delta-service</name>
   <description>Contact Hub Kalliope API</description>
   <licenses>
@@ -40,7 +40,7 @@
     <connection>
       scm:git:git@github.com:lblod/jsonld-delta-service.git
     </connection>
-    <tag>0.5.5-beta.1</tag>
+    <tag>HEAD</tag>
   </scm>
   <!-- <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>mu.semte.ch</groupId>
   <artifactId>jsonld-delta-service</artifactId>
-  <version>0.5.5-SNAPSHOT</version>
+  <version>0.5.5-beta.1</version>
   <name>jsonld-delta-service</name>
   <description>Contact Hub Kalliope API</description>
   <licenses>
@@ -40,7 +40,7 @@
     <connection>
       scm:git:git@github.com:lblod/jsonld-delta-service.git
     </connection>
-    <tag>HEAD</tag>
+    <tag>0.5.5-beta.1</tag>
   </scm>
   <!-- <repositories>
     <repository>

--- a/src/main/java/mu/semte/ch/api/kalliope/Constants.java
+++ b/src/main/java/mu/semte/ch/api/kalliope/Constants.java
@@ -1,18 +1,9 @@
 package mu.semte.ch.api.kalliope;
 
 public interface Constants {
-  String HEADER_MU_AUTH_SUDO = "mu-auth-sudo";
-
   String LOGICAL_FILE_PREFIX = "http://data.lblod.info/id/files";
-  String DELTA_INSERTS_GRAPH_PREFIX = "http://mu.semte.ch/graphs/kalliope/inserts";
-  String DELTA_DELETES_GRAPH_PREFIX = "http://mu.semte.ch/graphs/kalliope/deletes";
-  String DELTA_CHANGES_GRAPH_PREFIX = "http://mu.semte.ch/graphs/kalliope/changes";
   String DELTA_CONSOLIDATED_GRAPH_PREFIX = "http://mu.semte.ch/graphs/kalliope/consolidated";
 
-  String DELETE_ACTION = "http://schema.org/DeleteAction";
-  String INSERT_ACTION = "http://schema.org/InsertAction";
-
-  String ORGANIZATIONS_PRODUCER_GRAPH = "http://redpencil.data.gift/id/deltas/producer/organizations";
   String ORGANIZATIONS_DUMP_SUBJECT = "http://data.lblod.info/datasets/delta-producer/dumps/OrganizationsCacheGraphDump";
 
   String DC_DATE = "http://purl.org/dc/terms/date";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ sparql:
   defaultBatchSize: ${BATCH_SIZE:100}
   defaultLimitSize: ${LIMIT_SIZE:10000}
   maxRetry: ${MAX_RETRY:5}
+  authSudo: ${MU_AUTH_SUDO:true}
 
 spring:
   config:


### PR DESCRIPTION
In this service, the query gets data from types that are public. We can query them through mu-auth, not via sudo queries. It brings an extra security to the service.